### PR TITLE
feature: migrate from KAPT to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,11 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.parcelize)
 }
 
@@ -38,8 +40,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            // freeCompilerArgs.add("-XXLanguage:+PropertyParamAnnotationDefaultTargetMode")
+        }
     }
     buildFeatures {
         compose = true
@@ -79,7 +84,7 @@ dependencies {
     // Room
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
-    kapt(libs.androidx.room.compiler)
+    ksp(libs.androidx.room.compiler)
 
     // Networking
     implementation(libs.retrofit)
@@ -89,7 +94,7 @@ dependencies {
 
     // Dependency Injection
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
 
     // Image Loading

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.kotlin.ksp) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 # Core Android
-agp = "8.11.2"
+agp = "8.13.0"
 kotlin = "2.2.20"
 core-ktx = "1.17.0"
-lifecycle-runtime-ktx = "2.9.3"
+lifecycle-runtime-ktx = "2.9.4"
 activity-compose = "1.11.0"
 
 # Compose
@@ -11,7 +11,7 @@ compose-bom = "2025.09.00"
 compose-compiler = "1.5.7"
 
 # Architecture Components
-lifecycle-viewmodel-compose = "2.9.3"
+lifecycle-viewmodel-compose = "2.9.4"
 navigation-compose = "2.9.4"
 
 # Room
@@ -42,7 +42,8 @@ kotlinx-coroutines-test = "1.10.2"
 truth = "1.4.5"
 arch-core-testing = "2.2.0"
 hilt-android-testing = "2.57.1"
-navigation-testing = "2.7.4"
+navigation-testing = "2.9.4"
+ksp = "2.2.0-2.0.2"
 
 [libraries]
 # Core Android
@@ -106,3 +107,4 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt-android" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
feature: migrate from KAPT to KSP

Replace KAPT with KSP for annotation processing to improve
build performance and support Kotlin 2.0+